### PR TITLE
Clean css 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updates clean-css dependency to version 5.2.0
 
 ## [1.0.2] - 2021-08-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2021-09-25
 ### Changed
 - Updates clean-css dependency to version 5.2.0
 
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates clean-css dependency to version 5.1.4
 
 
-[Unreleased]: https://github.com/clean-css/clean-css.github.io/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/clean-css/clean-css.github.io/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/clean-css/clean-css.github.io/releases/tag/v1.1.0
 [1.0.2]: https://github.com/clean-css/clean-css.github.io/releases/tag/v1.0.2
 [1.0.1]: https://github.com/clean-css/clean-css.github.io/releases/tag/v1.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-app",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
     "start": "webpack serve --content-base public",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.0.1",
-    "clean-css": "^5.1.5",
+    "clean-css": "^5.2.0",
     "file-saver": "^2.0.5",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,10 +680,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.1.5.tgz#3b0af240dcfc9a3779a08c2332df3ebd4474f232"
-  integrity sha512-9dr/cU/LjMpU57PXlSvDkVRh0rPxJBXiBtD0+SgYt8ahTCsXtfKjCkNYgIoTC6mBg8CFr5EKhW3DKCaGMUbUfQ==
+clean-css@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.2.0.tgz#44e4a04e8873ff0041df97acecf23a4a6519844e"
+  integrity sha512-2639sWGa43EMmG7fn8mdVuBSs6HuWaSor+ZPoFWzenBc6oN+td8YhTfghWXZ25G1NiiSvz8bOFBS7PdSbTiqEA==
   dependencies:
     source-map "~0.6.0"
 


### PR DESCRIPTION
Clean-css is at 5.2.0 now. Do you think it's a good idea to bump the minor version (so 1.1.0) every time we bump minor clean-css version? May be clearer to follow later on.

/cc @johannchopin 